### PR TITLE
🧪 [testing improvement] Add edge case tests for isExpVersion

### DIFF
--- a/src/utils/helper.test.ts
+++ b/src/utils/helper.test.ts
@@ -1,0 +1,38 @@
+import { expect, test, describe } from "bun:test";
+import { isExpVersion } from "./helper";
+
+describe("isExpVersion", () => {
+  test("should return false when config is null", () => {
+    expect(isExpVersion(null, "1.0.0")).toBe(false);
+  });
+
+  test("should return false when config is undefined", () => {
+    expect(isExpVersion(undefined, "1.0.0")).toBe(false);
+  });
+
+  test("should return false when config.rollout is missing", () => {
+    // @ts-ignore
+    expect(isExpVersion({}, "1.0.0")).toBe(false);
+  });
+
+  test("should return false when rollout config for version is missing", () => {
+    expect(isExpVersion({ rollout: {} }, "1.0.0")).toBe(false);
+  });
+
+  test("should return false when rollout config for version is null", () => {
+    expect(isExpVersion({ rollout: { "1.0.0": null } }, "1.0.0")).toBe(false);
+  });
+
+  test("should return true when rollout is less than 100", () => {
+    expect(isExpVersion({ rollout: { "1.0.0": 50 } }, "1.0.0")).toBe(true);
+    expect(isExpVersion({ rollout: { "1.0.0": 0 } }, "1.0.0")).toBe(true);
+  });
+
+  test("should return false when rollout is 100", () => {
+    expect(isExpVersion({ rollout: { "1.0.0": 100 } }, "1.0.0")).toBe(false);
+  });
+
+  test("should return false when rollout is greater than 100", () => {
+    expect(isExpVersion({ rollout: { "1.0.0": 110 } }, "1.0.0")).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `isExpVersion` utility function in `src/utils/helper.ts`. 

The tests cover:
- Edge cases where the `config` object is `null` or `undefined`.
- Cases where the `rollout` property is missing or the specific version key within `rollout` is missing or `null`.
- Core logic verification ensuring percentages below 100 return `true` and 100 or above return `false`.

These tests improve the reliability of the version checking logic and guard against future regressions.

---
*PR created automatically by Jules for task [7958200876866584675](https://jules.google.com/task/7958200876866584675) started by @sunnylqm*