### PR TITLE
fix: add vip123 options to admin user management

### DIFF
--- a/src/pages/admin-users.tsx
+++ b/src/pages/admin-users.tsx
@@ -23,10 +23,13 @@ import { adminApi } from '@/services/admin-api';
 const { Title } = Typography;
 
 const tierOptions = [
-  ...Object.entries(quotas).map(([value, quota]) => ({
-    value,
-    label: quota.title,
-  })),
+  { value: 'free', label: '免费版' },
+  { value: 'standard', label: '标准版' },
+  { value: 'premium', label: '高级版' },
+  { value: 'pro', label: '专业版' },
+  { value: 'vip1', label: '大客户VIP1版' },
+  { value: 'vip2', label: '大客户VIP2版' },
+  { value: 'vip3', label: '大客户VIP3版' },
   { value: 'custom', label: '定制版' },
 ];
 

--- a/src/pages/admin-users.tsx
+++ b/src/pages/admin-users.tsx
@@ -17,9 +17,20 @@ import {
 import dayjs from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
 import { type Content, JSONEditor, type OnChange } from 'vanilla-jsoneditor';
+import { quotas } from '@/constants/quotas';
 import { adminApi } from '@/services/admin-api';
 
 const { Title } = Typography;
+
+const tierOptions = [
+  ...Object.entries(quotas).map(([value, quota]) => ({
+    value,
+    label: quota.title,
+  })),
+  { value: 'custom', label: '定制版' },
+];
+
+const tierLabelMap = new Map(tierOptions.map((option) => [option.value, option.label]));
 
 // JSON Editor wrapper component for quota editing
 const JsonEditorWrapper = ({
@@ -188,7 +199,8 @@ export const Component = () => {
       title: '套餐',
       dataIndex: 'tier',
       key: 'tier',
-      width: 100,
+      width: 120,
+      render: (tier: string) => tierLabelMap.get(tier) || tier || '-',
     },
     {
       title: '套餐过期时间',
@@ -278,13 +290,9 @@ export const Component = () => {
             </Form.Item>
             <Form.Item name="tier" label="套餐" className="mb-0!">
               <Select
-                options={[
-                  { value: 'free', label: '免费版' },
-                  { value: 'standard', label: '标准版' },
-                  { value: 'premium', label: '高级版' },
-                  { value: 'pro', label: '专业版' },
-                  { value: 'custom', label: '定制版' },
-                ]}
+                options={tierOptions}
+                optionFilterProp="label"
+                showSearch
               />
             </Form.Item>
             <Form.Item name="status" label="状态" className="mb-0!">


### PR DESCRIPTION
## Summary\n- add VIP1/VIP2/VIP3 tier options to admin user management\n- keep user tier labels aligned with available admin-select options\n\n## Testing\n- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable tier selection when managing users.

* **Improvements**
  * Tier information now displays with clear, readable labels instead of raw values.
  * Increased tier column width for better layout visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->