### PR TITLE
feat: prefill premium quota in admin users

### DIFF
--- a/src/pages/admin-users.tsx
+++ b/src/pages/admin-users.tsx
@@ -34,6 +34,7 @@ const tierOptions = [
 ];
 
 const tierLabelMap = new Map(tierOptions.map((option) => [option.value, option.label]));
+const defaultPremiumQuotaText = JSON.stringify(quotas.premium, null, 2);
 
 // JSON Editor wrapper component for quota editing
 const JsonEditorWrapper = ({
@@ -131,7 +132,11 @@ export const Component = () => {
       status: record.status,
       tierExpiresAt: record.tierExpiresAt ? dayjs(record.tierExpiresAt) : null,
     });
-    setQuotaValue(record.quota ? JSON.stringify(record.quota, null, 2) : '');
+    setQuotaValue(
+      record.quota
+        ? JSON.stringify(record.quota, null, 2)
+        : defaultPremiumQuotaText,
+    );
     setIsModalOpen(true);
   };
 


### PR DESCRIPTION
## Summary\n- prefill custom quota with the premium tier defaults when a user has no custom quota\n- keep existing custom quota values unchanged for users who already have one\n\n## Testing\n- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default quota display in the user management panel so that when editing users without a preset quota, the default premium quota value now appears instead of an empty field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->