### PR TITLE
🧹 [code health] refactor Record<any, any> to safer types in request service

### DIFF
--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -57,10 +57,10 @@ export interface RequestOptions {
   suppressErrorToast?: boolean;
 }
 
-export default async function request<T extends Record<any, any>>(
+export default async function request<T = unknown>(
   method: 'get' | 'post' | 'put' | 'delete',
   path: string,
-  params?: Record<any, any>,
+  params?: Record<string, unknown>,
   requestOptions: RequestOptions = {},
 ) {
   const headers: HeadersInit = {};
@@ -72,7 +72,7 @@ export default async function request<T extends Record<any, any>>(
   }
   if (params) {
     if (method === 'get') {
-      url += `?${new URLSearchParams(params).toString()}`;
+      url += `?${new URLSearchParams(params as Record<string, string>).toString()}`;
     } else {
       headers['content-type'] = 'application/json';
       options.body = JSON.stringify(params);


### PR DESCRIPTION
🎯 **What:**
The code health issue in `src/services/request.ts` where `Record<any, any>` was used has been addressed. The default generic type `T` has been changed from `T extends Record<any, any>` to `T = unknown`. Additionally, the type of the `params` argument has been updated from `Record<any, any>` to `Record<string, unknown>`.

💡 **Why:**
Using `any` undermines TypeScript's type safety. Replacing `Record<any, any>` with `Record<string, unknown>` provides stronger type-checking, preventing unintended runtime errors and making the codebase safer and easier to maintain. Making `T = unknown` rather than extending `Record<string, unknown>` ensures compatibility with TypeScript interfaces that do not implicitly declare string index signatures.

✅ **Verification:**
* Verified that formatting and typing checks pass using `npm run lint`.
* Verified that the test suite continues to pass via `bun test`.
* Validated that type checking via `.ts` builds functions effectively for `request.ts` usages.

✨ **Result:**
The `request` service API has been improved for better strict typing, eliminating usages of `any` while still supporting backwards compatibility for the existing components relying on it.

---
*PR created automatically by Jules for task [8075805081112997007](https://jules.google.com/task/8075805081112997007) started by @sunnylqm*