### PR TITLE
🧪 [add unit test for auth.ts]

### DIFF
--- a/bun-test-setup.ts
+++ b/bun-test-setup.ts
@@ -17,5 +17,37 @@ mock.module('@/services/api', () => ({
 }));
 mock.module('@/services/request', () => ({
   getToken: () => '',
+  setToken: () => {},
+  RequestError: class extends Error {},
   default: {},
+}));
+mock.module('@/assets/logo-h.svg', () => ({
+  default: 'logo',
+  ReactComponent: () => null,
+}));
+mock.module('@/assets/logo.png', () => ({
+  default: 'logo.png',
+}));
+mock.module('react-router-dom', () => ({
+  createHashRouter: () => ({
+    state: { location: { search: '', pathname: '' } },
+    navigate: () => {},
+  }),
+  redirect: () => {},
+  useNavigate: () => {},
+  useRouteError: () => {},
+  isRouteErrorResponse: () => false,
+  Link: () => null,
+  NavLink: () => null,
+  Outlet: () => null,
+  useLocation: () => ({
+    pathname: '',
+    search: '',
+    hash: '',
+    state: null,
+    key: 'default',
+  }),
+  useSearchParams: () => [new URLSearchParams(), () => {}],
+  useLoaderData: () => null,
+  useActionData: () => null,
 }));

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -25,16 +25,27 @@ declare module 'bun:test' {
   type TestHandler = () => void | Promise<void>;
 
   export function describe(name: string, fn: TestHandler): void;
+  export function it(name: string, fn: TestHandler): void;
   export function test(name: string, fn: TestHandler): void;
   export function expect<T>(actual: T): {
     toBe(expected: unknown): void;
     toBeNull(): void;
+    toContain(expected: unknown): void;
+    toHaveBeenCalledWith(...args: unknown[]): void;
+    toHaveBeenCalled(): void;
+    not: {
+      toHaveBeenCalledWith(...args: unknown[]): void;
+      toHaveBeenCalled(): void;
+    };
   };
   export function beforeEach(fn: () => void | Promise<void>): void;
   export function afterEach(fn: () => void | Promise<void>): void;
   export function setSystemTime(time: Date | number | null): void;
   export const mock: {
     module(path: string, factory: () => any): void;
+    <T extends (...args: any[]) => any>(
+      fn?: T,
+    ): T & { mockClear(): void; mockImplementationOnce(fn: T): void };
   };
 }
 

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// In order to avoid environment setup issues with react-router-dom and other DOM dependencies during test execution
+// in bun, we can mock out the internal dependencies and the router directly.
+
+const mockNavigate = mock(() => {});
+const mockRouterObj = {
+  state: {
+    location: {
+      search: '',
+      pathname: '/current-path',
+    },
+  },
+  navigate: mockNavigate,
+};
+
+mock.module('@/router', () => ({
+  rootRouterPath: {
+    apps: '/',
+    inactivated: '/inactivated',
+    login: '/login',
+  },
+  router: mockRouterObj,
+}));
+
+const mockMessage = {
+  success: mock(() => {}),
+  error: mock(() => {}),
+};
+
+mock.module('antd', () => ({
+  message: mockMessage,
+}));
+
+const mockApiObj = {
+  login: mock(async () => ({ token: 'fake-token' })),
+};
+
+mock.module('@/services/api', () => ({
+  api: mockApiObj,
+}));
+
+mock.module('hash-wasm', () => ({
+  md5: mock(async (str) => `md5-${str}`),
+}));
+
+class MockRequestError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'RequestError';
+    this.status = status;
+  }
+}
+
+const mockSetTokenObj = mock(() => {});
+
+mock.module('@/services/request', () => ({
+  RequestError: MockRequestError,
+  setToken: mockSetTokenObj,
+}));
+
+// Provide react-router-dom mock globally to stop "Cannot parse URL /" on router load when using happy-dom
+mock.module('react-router-dom', () => ({
+  createHashRouter: () => ({
+    state: { location: { search: '', pathname: '' } },
+    navigate: () => {},
+  }),
+  redirect: () => {},
+  useNavigate: () => {}, // mock useNavigate because it failed on export earlier
+}));
+
+// Mock main-layout because it imports logo which causes the SVG error
+mock.module('@/components/main-layout', () => ({
+  default: () => null,
+}));
+
+// Now import the functions to test
+import { getUserEmail, login, logout, setUserEmail } from './auth';
+
+describe('auth.ts runtime test', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    mockMessage.success.mockClear();
+    mockMessage.error.mockClear();
+    mockNavigate.mockClear();
+    mockSetTokenObj.mockClear();
+    mockApiObj.login.mockClear();
+    setUserEmail('');
+
+    mockRouterObj.state.location.search = '';
+    mockRouterObj.state.location.pathname = '/current-path';
+
+    // We mock window.location.reload because logout calls it.
+    originalLocation = global.window
+      ? global.window.location
+      : ({} as Location);
+    if (!global.window) {
+      global.window = {} as any;
+    }
+
+    Object.defineProperty(global.window, 'location', {
+      value: { ...originalLocation, reload: mock(() => {}) },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global.window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('should get and set user email', () => {
+    setUserEmail('test@email.com');
+    expect(getUserEmail()).toBe('test@email.com');
+  });
+
+  describe('login', () => {
+    it('should successfully login and navigate to apps if no loginFrom is present', async () => {
+      await login('test@email.com', 'mypassword');
+
+      expect(getUserEmail()).toBe('test@email.com');
+      expect(mockApiObj.login).toHaveBeenCalledWith({
+        email: 'test@email.com',
+        pwd: 'md5-mypassword',
+      });
+      expect(mockSetTokenObj).toHaveBeenCalledWith('fake-token');
+      expect(mockMessage.success).toHaveBeenCalledWith('登录成功');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+
+    it('should navigate to loginFrom if it is a valid path', async () => {
+      mockRouterObj.state.location.search = '?loginFrom=/user/settings';
+      await login('test@email.com', 'mypassword');
+
+      expect(mockNavigate).toHaveBeenCalledWith('/user/settings');
+    });
+
+    it('should navigate to default / if loginFrom is external //', async () => {
+      mockRouterObj.state.location.search = '?loginFrom=//evil.com';
+      await login('test@email.com', 'mypassword');
+
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+
+    it('should navigate to inactivated page if 423 RequestError occurs', async () => {
+      mockApiObj.login.mockImplementationOnce(async () => {
+        throw new MockRequestError('Account inactive', 423);
+      });
+
+      await login('test@email.com', 'mypassword');
+
+      expect(mockNavigate).toHaveBeenCalledWith('/inactivated');
+      expect(mockMessage.error).not.toHaveBeenCalled();
+    });
+
+    it('should display error message on other errors', async () => {
+      mockApiObj.login.mockImplementationOnce(async () => {
+        throw new Error('Server error');
+      });
+
+      await login('test@email.com', 'mypassword');
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockMessage.error).toHaveBeenCalledWith('Server error');
+    });
+  });
+
+  describe('logout', () => {
+    it('should set token to empty string, navigate to login, and reload', () => {
+      mockRouterObj.state.location.pathname = '/apps';
+
+      logout();
+
+      expect(mockSetTokenObj).toHaveBeenCalledWith('');
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(global.window.location.reload).toHaveBeenCalled();
+    });
+
+    it('should skip navigate to login if already on login page', () => {
+      mockRouterObj.state.location.pathname = '/login';
+
+      logout();
+
+      expect(mockSetTokenObj).toHaveBeenCalledWith('');
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(global.window.location.reload).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `src/services/auth.ts` lacked a test file to verify its logic, such as password hashing, token saving, routing behavior on errors, and valid/invalid login redirects.
📊 **Coverage:** Tests now cover happy paths (successful login setting email and token), edge cases (`loginFrom` parameter with valid paths vs. invalid external urls), error conditions (423 RequestError for inactivated accounts, general errors), and the logout function.
✨ **Result:** Increased test coverage by providing a runtime unit test for `auth.ts` that mocks routing and API dependencies effectively without relying on static analysis.

---
*PR created automatically by Jules for task [10673231160963555083](https://jules.google.com/task/10673231160963555083) started by @sunnylqm*