### PR TITLE
🔒 [Security Fix] Prevent DOM XSS in git commit URL

### DIFF
--- a/src/pages/manage/components/commit.tsx
+++ b/src/pages/manage/components/commit.tsx
@@ -36,6 +36,18 @@ export const Commit = ({ commit }: { commit?: Commit }) => {
     }
   }
 
+  // Validate URL protocol to prevent XSS
+  if (url) {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        url = '';
+      }
+    } catch {
+      url = '';
+    }
+  }
+
   const time = dayjs(+commit.timestamp * 1000);
 
   return (


### PR DESCRIPTION
🎯 **What:**
The `href` attribute of the anchor tag displaying the commit hash link was not properly validated. If a commit payload contained a manipulated URL string, the application could potentially fall back to or be coerced into using an unsafe URL protocol (like `javascript:`).

⚠️ **Risk:**
This represents a Cross-Site Scripting (XSS) vulnerability. If an attacker managed to construct a git origin or commit URL that utilized the `javascript:` protocol, users clicking on the link to view commit details could unknowingly execute malicious JavaScript in the context of the application dashboard. This could lead to token theft or unauthorized actions.

🛡️ **Solution:**
Added strict protocol validation using the native `URL` constructor. Before the anchor tag uses the `url`, it is parsed using `new URL()`. The resulting `protocol` property is checked against a whitelist (`'http:'` and `'https:'`). If the URL fails parsing or uses a malicious scheme, it is cleared (`url = ''`), causing the UI to gracefully fallback to displaying plain text instead of a vulnerable link.

---
*PR created automatically by Jules for task [12342675524827216816](https://jules.google.com/task/12342675524827216816) started by @sunnylqm*