### PR TITLE
🧪 [testing improvement] Add error path test for getRecentAppIds

### DIFF
--- a/src/utils/helper.test.ts
+++ b/src/utils/helper.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from 'bun:test';
-import { isExpVersion, isPasswordValid } from './helper';
+import { describe, expect, test, mock } from 'bun:test';
+import {
+  MAX_RECENT_APP_COUNT,
+  RECENT_APP_STORAGE_KEY,
+  getRecentAppIds,
+  isExpVersion,
+  isPasswordValid,
+  rememberRecentApp,
+} from './helper';
 
 describe('isPasswordValid', () => {
   test('should return true for valid passwords', () => {
@@ -98,5 +105,113 @@ describe('isValidExternalUrl', () => {
 
   test('should return false for javascript uris', () => {
     expect(isValidExternalUrl('javascript:alert(1)')).toBe(false);
+  });
+});
+
+describe('RecentAppIds', () => {
+  const originalWindow = (global as any).window;
+
+  test('getRecentAppIds should return empty array when window is undefined', () => {
+    (global as any).window = undefined;
+    expect(getRecentAppIds()).toEqual([]);
+    (global as any).window = originalWindow;
+  });
+
+  test('getRecentAppIds should return parsed array from localStorage', () => {
+    const mockStorage = {
+      getItem: mock(() => JSON.stringify([1, 2, 3])),
+    };
+    (global as any).window = { localStorage: mockStorage };
+
+    expect(getRecentAppIds()).toEqual([1, 2, 3]);
+    expect(mockStorage.getItem).toHaveBeenCalledWith(RECENT_APP_STORAGE_KEY);
+
+    (global as any).window = originalWindow;
+  });
+
+  test('getRecentAppIds should return empty array on invalid JSON', () => {
+    const mockStorage = {
+      getItem: mock(() => 'invalid json'),
+    };
+    (global as any).window = { localStorage: mockStorage };
+
+    expect(getRecentAppIds()).toEqual([]);
+
+    (global as any).window = originalWindow;
+  });
+
+  test('getRecentAppIds should return empty array when parsed value is not an array', () => {
+    const mockStorage = {
+      getItem: mock(() => JSON.stringify({ a: 1 })),
+    };
+    (global as any).window = { localStorage: mockStorage };
+
+    expect(getRecentAppIds()).toEqual([]);
+
+    (global as any).window = originalWindow;
+  });
+
+  test('getRecentAppIds should filter out non-integer values', () => {
+    const mockStorage = {
+      getItem: mock(() => JSON.stringify([1, '2', 3.5, 4])),
+    };
+    (global as any).window = { localStorage: mockStorage };
+
+    expect(getRecentAppIds()).toEqual([1, 4]);
+
+    (global as any).window = originalWindow;
+  });
+
+  test('rememberRecentApp should add appId to the front and limit count', () => {
+    let storage: Record<string, string> = {
+      [RECENT_APP_STORAGE_KEY]: JSON.stringify([2, 1]),
+    };
+    const mockStorage = {
+      getItem: mock((key: string) => storage[key] ?? null),
+      setItem: mock((key: string, value: string) => {
+        storage[key] = value;
+      }),
+    };
+    (global as any).window = {
+      localStorage: mockStorage,
+    };
+
+    const result = rememberRecentApp(3);
+    expect(result).toEqual([3, 2, 1]);
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      RECENT_APP_STORAGE_KEY,
+      JSON.stringify([3, 2, 1]),
+    );
+
+    // Test deduplication
+    const result2 = rememberRecentApp(2);
+    expect(result2).toEqual([2, 3, 1]);
+
+    // Test limit
+    storage[RECENT_APP_STORAGE_KEY] = JSON.stringify([1, 2, 3, 4, 5, 6]);
+    const result3 = rememberRecentApp(7);
+    expect(result3.length).toBe(MAX_RECENT_APP_COUNT);
+    expect(result3).toEqual([7, 1, 2, 3, 4, 5]);
+
+    (global as any).window = originalWindow;
+  });
+
+  test('rememberRecentApp should return empty array when window is undefined', () => {
+    (global as any).window = undefined;
+    expect(rememberRecentApp(1)).toEqual([]);
+    (global as any).window = originalWindow;
+  });
+
+  test('rememberRecentApp should return empty array when appId is not an integer', () => {
+    const mockStorage = {
+      getItem: mock(() => JSON.stringify([])),
+      setItem: mock(() => {}),
+    };
+    (global as any).window = { localStorage: mockStorage };
+
+    expect(rememberRecentApp(1.5)).toEqual([]);
+    expect(mockStorage.setItem).not.toHaveBeenCalled();
+
+    (global as any).window = originalWindow;
   });
 });

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -90,8 +90,8 @@ export const patchSearchParams = (
   }, navigateOptions);
 };
 
-const RECENT_APP_STORAGE_KEY = 'pushy_recent_app_ids';
-const MAX_RECENT_APP_COUNT = 6;
+export const RECENT_APP_STORAGE_KEY = 'pushy_recent_app_ids';
+export const MAX_RECENT_APP_COUNT = 6;
 const MANAGE_APP_DRAWER_PLACEMENT_STORAGE_KEY =
   'pushy_manage_app_drawer_placement';
 const MANAGE_APP_DRAWER_COLLAPSED_STORAGE_KEY =


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing error path test for `getRecentAppIds` when `localStorage` contains invalid JSON. This PR adds that test case and comprehensive coverage for the entire recent apps feature.

📊 **Coverage:**
- **getRecentAppIds**:
  - Handles `window` being `undefined`.
  - Successfully parses valid JSON arrays from `localStorage`.
  - Returns an empty array on invalid JSON (the requested error path).
  - Returns an empty array when the stored value is not an array.
  - Filters out non-integer values from the stored array.
- **rememberRecentApp**:
  - Corrects adds new app IDs to the front.
  - Handles deduplication of app IDs.
  - Enforces the `MAX_RECENT_APP_COUNT` limit.
  - Handles error cases like `window` being `undefined` or invalid `appId` types.

✨ **Result:** Increased reliability and test coverage for the recent apps management utility.

---
*PR created automatically by Jules for task [11677145689250762709](https://jules.google.com/task/11677145689250762709) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for recent app tracking functionality, including edge cases and data validation scenarios.

* **Refactor**
  * Exposed internal storage constants for broader reuse across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->