### PR TITLE
Fix admin user null statistics

### DIFF
--- a/src/pages/admin-users.tsx
+++ b/src/pages/admin-users.tsx
@@ -349,36 +349,44 @@ const UserDetailDrawer = ({
                 })}
               </Descriptions.Item>
               <Descriptions.Item label={translate('admin_users.today_used')}>
-                {t('admin_users.checks_value', {
-                  value: detail.quotaDetail.todayUsed,
-                })}
+                {detail.quotaDetail.todayUsed === null
+                  ? '-'
+                  : t('admin_users.checks_value', {
+                      value: detail.quotaDetail.todayUsed,
+                    })}
               </Descriptions.Item>
               <Descriptions.Item
                 label={translate('admin_users.today_remaining')}
               >
-                {t('admin_users.checks_value', {
-                  value: detail.quotaDetail.todayRemaining,
-                })}
+                {detail.quotaDetail.todayRemaining === null
+                  ? '-'
+                  : t('admin_users.checks_value', {
+                      value: detail.quotaDetail.todayRemaining,
+                    })}
               </Descriptions.Item>
               <Descriptions.Item label={translate('admin_users.avg_7_days')}>
-                {t('admin_users.checks_value', {
-                  value: detail.quotaDetail.last7Days.avg,
-                })}
+                {detail.quotaDetail.last7Days
+                  ? t('admin_users.checks_value', {
+                      value: detail.quotaDetail.last7Days.avg,
+                    })
+                  : '-'}
               </Descriptions.Item>
               <Descriptions.Item
                 label={translate('admin_users.last_7_days_details')}
                 span={2}
               >
-                {detail.quotaDetail.last7Days.counts
-                  .slice()
-                  .reverse()
-                  .map((c, i) => (
-                    // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length ordered day list, index is the stable identity
-                    <span key={i} className="mr-3 inline-block">
-                      {t('admin_users.day_label', { day: i + 1 })}:{' '}
-                      <strong>{c}</strong>
-                    </span>
-                  ))}
+                {detail.quotaDetail.last7Days
+                  ? detail.quotaDetail.last7Days.counts
+                      .slice()
+                      .reverse()
+                      .map((c, i) => (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length ordered day list, index is the stable identity
+                        <span key={i} className="mr-3 inline-block">
+                          {t('admin_users.day_label', { day: i + 1 })}:{' '}
+                          <strong>{c}</strong>
+                        </span>
+                      ))
+                  : '-'}
               </Descriptions.Item>
               <Descriptions.Item label={translate('admin_users.app_limit')}>
                 {detail.apps.length} / {detail.quotaDetail.limit.app}
@@ -408,7 +416,7 @@ const UserDetailDrawer = ({
                         </span>
                         <Space size="middle">
                           <span>
-                            PV: <strong>{app.checkCount}</strong>
+                            PV: <strong>{app.checkCount ?? '-'}</strong>
                           </span>
                           <span>
                             {translate('admin_users.packages_count')}:{' '}

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -150,16 +150,16 @@ export const adminApi = {
       };
       quotaDetail: {
         limit: Quota;
-        todayRemaining: number;
-        todayUsed: number;
+        todayRemaining: number | null;
+        todayUsed: number | null;
         last7Days: {
           counts: number[];
           avg: number;
-        };
+        } | null;
       };
       apps: Array<
         AdminApp & {
-          checkCount: number;
+          checkCount: number | null;
           packagesCount: number;
         }
       >;


### PR DESCRIPTION
## What changed

- Treat Redis-backed user quota statistics as nullable in the admin API contract.
- Render unavailable quota statistics and app PV counts as `-` in the user detail drawer.

## Why

When Redis statistics are unavailable, the server intentionally returns `last7Days`, today's quota values, and app check counts as `null`. The admin UI assumed those values were always present and crashed while reading `last7Days.avg`.

## Impact

The `/admin-users` detail drawer now remains usable during Redis statistics degradation and clearly marks unavailable values.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun test` (249 passed)
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/pushy-admin/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788914048&installation_model_id=426977&pr_number=59&repository=reactnativecn%2Fpushy-admin&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Fpushy-admin%2Fpull%2F59&signature=708f5520c047e82f0e4d3f72856f3f4870b8129216f3bcca347ba6e449730a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->