### PR TITLE
fix: harden admin runtime correctness and recovery

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'pushy-admin-v2';
+const CACHE_NAME = 'pushy-admin-v3';
+const MAX_CACHE_ENTRIES = 80;
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
 const IS_LOCAL_HOST = LOCAL_HOSTNAMES.has(self.location.hostname);
 
@@ -27,6 +28,13 @@ self.addEventListener('activate', (event) => {
 const isNavigationRequest = (request) =>
   request.mode === 'navigate' ||
   (request.headers.get('accept') || '').includes('text/html');
+
+const trimCache = async (cache) => {
+  const keys = await cache.keys();
+  const excess = keys.length - MAX_CACHE_ENTRIES;
+  if (excess <= 0) return;
+  await Promise.all(keys.slice(0, excess).map((request) => cache.delete(request)));
+};
 
 // Fetch: keep HTML/API fresh; cache only fingerprinted static assets.
 self.addEventListener('fetch', (event) => {
@@ -58,15 +66,16 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    caches.match(request).then((cached) => {
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cached = await cache.match(request);
       if (cached) return cached;
-      return fetch(request).then((response) => {
-        if (response.ok && url.origin === self.location.origin) {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
-        }
-        return response;
-      });
+
+      const response = await fetch(request);
+      if (response.ok && url.origin === self.location.origin) {
+        await cache.put(request, response.clone());
+        await trimCache(cache);
+      }
+      return response;
     }),
   );
 });

--- a/src/components/admin-route.tsx
+++ b/src/components/admin-route.tsx
@@ -1,15 +1,37 @@
-import { Spin } from 'antd';
+import { useQuery } from '@tanstack/react-query';
+import { Button, Result, Spin } from 'antd';
+import { useTranslation } from 'react-i18next';
 import { Navigate, Outlet } from 'react-router-dom';
-import { useUserInfo } from '@/utils/hooks';
+import { rootRouterPath } from '@/router';
+import { api } from '@/services/api';
+import { hasSession } from '@/services/request';
+import { userKeys } from '@/utils/query-keys';
 
 /**
  * 管理员路由的门控：子路由用 react-router 自带的 `lazy` 按需加载，
- * 这里只负责在用户信息就绪前占位、非管理员时跳走。
+ * 这里只负责等待用户信息、处理读取失败并拦截非管理员。
  */
 export function AdminRoute() {
-  const { isLoading, user } = useUserInfo();
+  const { t } = useTranslation();
+  const sessionAvailable = hasSession();
+  const {
+    data: user,
+    error,
+    isError,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: userKeys.info(),
+    queryFn: api.me,
+    enabled: sessionAvailable,
+  });
 
-  if (isLoading || user === undefined) {
+  if (!sessionAvailable) {
+    return <Navigate replace to={rootRouterPath.login} />;
+  }
+
+  if (isLoading || (!isError && user === undefined)) {
     return (
       <div className="page-section flex min-h-64 items-center justify-center">
         <Spin />
@@ -17,8 +39,33 @@ export function AdminRoute() {
     );
   }
 
+  if (isError) {
+    return (
+      <div className="page-section">
+        <Result
+          status="error"
+          title={t('error_boundary.title')}
+          subTitle={
+            error instanceof Error && error.message
+              ? error.message
+              : t('error_boundary.unknown_error')
+          }
+          extra={
+            <Button
+              loading={isFetching}
+              type="primary"
+              onClick={() => void refetch()}
+            >
+              {t('error_boundary.retry')}
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
   if (!user?.admin) {
-    return <Navigate replace to="/apps" />;
+    return <Navigate replace to={rootRouterPath.apps} />;
   }
 
   return <Outlet />;

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -2,12 +2,14 @@ import { Button, Result } from 'antd';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useRouteError } from 'react-router-dom';
+import {
+  CHUNK_ERROR_RELOAD_KEY,
+  shouldReloadChunkError,
+} from '@/utils/chunk-recovery';
 
 interface ChunkError extends Error {
   __webpack_chunkName?: string;
 }
-
-const CHUNK_ERROR_RELOAD_KEY = 'pushy_chunk_error_reload_attempted';
 
 const isLocalHost = () => {
   const { hostname } = window.location;
@@ -34,22 +36,25 @@ export function ErrorBoundary() {
 
   useEffect(() => {
     if (!isChunkError) {
-      window.sessionStorage.removeItem(CHUNK_ERROR_RELOAD_KEY);
       return;
     }
 
+    const currentVersion = process.env.PUBLIC_UI_VERSION || 'unknown';
+    const attemptedVersion = window.sessionStorage.getItem(
+      CHUNK_ERROR_RELOAD_KEY,
+    );
     if (
       process.env.NODE_ENV === 'production' &&
       !isLocalHost() &&
-      !window.sessionStorage.getItem(CHUNK_ERROR_RELOAD_KEY)
+      shouldReloadChunkError(attemptedVersion, currentVersion)
     ) {
-      window.sessionStorage.setItem(CHUNK_ERROR_RELOAD_KEY, '1');
+      window.sessionStorage.setItem(CHUNK_ERROR_RELOAD_KEY, currentVersion);
       window.location.reload();
     }
   }, [isChunkError]);
 
   const handleRetry = () => {
-    navigate(-1);
+    window.location.reload();
   };
 
   const handleGoHome = () => {

--- a/src/components/switch-endpoint-modal.tsx
+++ b/src/components/switch-endpoint-modal.tsx
@@ -67,10 +67,7 @@ export function SwitchEndpointModal({
     try {
       const ok = await testEndpointStatus(normalizedUrl);
       if (ok) {
-        applyEndpointChange(
-          normalizedUrl,
-          t('admin_endpoint.test_success'),
-        );
+        applyEndpointChange(normalizedUrl, t('admin_endpoint.test_success'));
       } else {
         message.error(t('admin_endpoint.test_failed'));
       }

--- a/src/components/switch-endpoint-modal.tsx
+++ b/src/components/switch-endpoint-modal.tsx
@@ -1,11 +1,15 @@
 import { Button, Form, Input, Modal, message, Tag } from 'antd';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { clearSession } from '@/services/request';
+import { clearWorkspace } from '@/services/workspace';
 import {
+  normalizeEndpointUrl,
   setCustomBaseUrl,
   testEndpointStatus,
   useCustomBaseUrl,
 } from '@/utils/endpoint';
+import { queryClient } from '@/utils/queryClient';
 
 interface SwitchEndpointModalProps {
   onClose: () => void;
@@ -27,25 +31,46 @@ export function SwitchEndpointModal({
     }
   }, [open, currentCustomUrl]);
 
-  const handleSave = async () => {
-    const trimmed = urlInput.trim();
-    if (!trimmed) {
-      handleReset();
+  const applyEndpointChange = (
+    nextUrl: string | null,
+    successMessage: string,
+  ) => {
+    const currentNormalized = currentCustomUrl
+      ? normalizeEndpointUrl(currentCustomUrl)
+      : null;
+    if (currentNormalized === nextUrl) {
+      message.success(successMessage);
+      onClose();
       return;
     }
 
-    if (!/^https?:\/\//i.test(trimmed)) {
+    // An API origin is an authentication boundary. Drop the old token,
+    // workspace and cached responses before publishing the new endpoint so no
+    // request can carry credentials or data across servers.
+    clearSession();
+    clearWorkspace();
+    queryClient.clear();
+    setCustomBaseUrl(nextUrl);
+    message.success(successMessage);
+    onClose();
+    window.location.reload();
+  };
+
+  const handleSave = async () => {
+    const normalizedUrl = normalizeEndpointUrl(urlInput);
+    if (!normalizedUrl) {
       message.error(t('admin_endpoint.invalid_url'));
       return;
     }
 
     setTesting(true);
     try {
-      const ok = await testEndpointStatus(trimmed);
+      const ok = await testEndpointStatus(normalizedUrl);
       if (ok) {
-        setCustomBaseUrl(trimmed);
-        message.success(t('admin_endpoint.test_success'));
-        onClose();
+        applyEndpointChange(
+          normalizedUrl,
+          t('admin_endpoint.test_success'),
+        );
       } else {
         message.error(t('admin_endpoint.test_failed'));
       }
@@ -57,10 +82,8 @@ export function SwitchEndpointModal({
   };
 
   const handleReset = () => {
-    setCustomBaseUrl(null);
     setUrlInput('');
-    message.success(t('admin_endpoint.reset_success'));
-    onClose();
+    applyEndpointChange(null, t('admin_endpoint.reset_success'));
   };
 
   return (

--- a/src/components/user-detail-drawer.tsx
+++ b/src/components/user-detail-drawer.tsx
@@ -97,6 +97,8 @@ export const UserDetailDrawer = ({
   });
 
   const translate = (key: string) => t(key);
+  const renderChecks = (value: number | null | undefined) =>
+    value == null ? '-' : t('admin_users.checks_value', { value });
 
   const detail = data;
 
@@ -201,41 +203,35 @@ export const UserDetailDrawer = ({
               column={2}
             >
               <Descriptions.Item label={translate('admin_users.pv_limit')}>
-                {t('admin_users.checks_value', {
-                  value: detail.quotaDetail.limit.pv,
-                })}
+                {renderChecks(detail.quotaDetail.limit.pv)}
               </Descriptions.Item>
               <Descriptions.Item label={translate('admin_users.today_used')}>
-                {t('admin_users.checks_value', {
-                  value: detail.quotaDetail.todayUsed,
-                })}
+                {renderChecks(detail.quotaDetail.todayUsed)}
               </Descriptions.Item>
               <Descriptions.Item
                 label={translate('admin_users.today_remaining')}
               >
-                {t('admin_users.checks_value', {
-                  value: detail.quotaDetail.todayRemaining,
-                })}
+                {renderChecks(detail.quotaDetail.todayRemaining)}
               </Descriptions.Item>
               <Descriptions.Item label={translate('admin_users.avg_7_days')}>
-                {t('admin_users.checks_value', {
-                  value: detail.quotaDetail.last7Days.avg,
-                })}
+                {renderChecks(detail.quotaDetail.last7Days?.avg)}
               </Descriptions.Item>
               <Descriptions.Item
                 label={translate('admin_users.last_7_days_details')}
                 span={2}
               >
-                {detail.quotaDetail.last7Days.counts
-                  .slice()
-                  .reverse()
-                  .map((c, i) => (
-                    // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length ordered day list, index is the stable identity
-                    <span key={i} className="mr-3 inline-block">
-                      {t('admin_users.day_label', { day: i + 1 })}:{' '}
-                      <strong>{c}</strong>
-                    </span>
-                  ))}
+                {detail.quotaDetail.last7Days
+                  ? detail.quotaDetail.last7Days.counts
+                      .slice()
+                      .reverse()
+                      .map((count, index) => (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length ordered day list, index is the stable identity
+                        <span key={index} className="mr-3 inline-block">
+                          {t('admin_users.day_label', { day: index + 1 })}:{' '}
+                          <strong>{count}</strong>
+                        </span>
+                      ))
+                  : '-'}
               </Descriptions.Item>
               <Descriptions.Item label={translate('admin_users.app_limit')}>
                 {detail.apps.length} / {detail.quotaDetail.limit.app}
@@ -265,7 +261,7 @@ export const UserDetailDrawer = ({
                         </span>
                         <Space size="middle">
                           <span>
-                            PV: <strong>{app.checkCount}</strong>
+                            PV: <strong>{app.checkCount ?? '-'}</strong>
                           </span>
                           <span>
                             {translate('admin_users.packages_count')}:{' '}

--- a/src/pages/admin-metrics.logic.test.ts
+++ b/src/pages/admin-metrics.logic.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_RANGE_HOURS,
   formatTooltipItem,
   getCategoryPrefix,
+  getDistributionCategoryOrder,
   getMetricsTotal,
   type MetricsResponse,
   parseDateRange,
@@ -50,6 +51,17 @@ describe('distribution tabs and points', () => {
       },
     ]);
   });
+
+  test('ranks legend categories by real volume instead of equal-weight daily share', () => {
+    const points = buildDistributionPoints([
+      { date: '2026-08-10', values: { x: 1 } },
+      { date: '2026-08-11', values: { x: 100, y: 900 } },
+    ]);
+
+    // Percentage sums would rank x first (100% + 10% versus y's 90%), but
+    // the actual window volumes are y=900 and x=101.
+    expect(getDistributionCategoryOrder(points)).toEqual(['y', 'x']);
+  });
 });
 
 describe('getCategoryPrefix', () => {
@@ -72,7 +84,7 @@ describe('getMetricsTotal', () => {
 
   test('sums every category when no _total is present', () => {
     const metrics: MetricsResponse = {
-      dict: ['rn0.72', 'rn0.73'],
+      dict: ['rn\u001f0.72', 'rn\u001f0.73'],
       data: [
         {
           time: 't1',
@@ -89,7 +101,7 @@ describe('getMetricsTotal', () => {
 
   test('a _total entry overrides the running sum for its bucket', () => {
     const metrics: MetricsResponse = {
-      dict: ['rn0.72', '_total', 'rn0.73'],
+      dict: ['rn\u001f0.72', '_total', 'rn\u001f0.73'],
       data: [
         // 前面已累加 3,遇到 _total 后以 10 为准,后面的 100 不再计入
         {
@@ -114,7 +126,7 @@ describe('buildChartPoints', () => {
 
   test('splits dict keys on the separator and skips _total', () => {
     const metrics: MetricsResponse = {
-      dict: ['rn0.72', '_total', 'os', 'plain'],
+      dict: ['rn\u001f0.72', '_total', 'os\u001f', 'plain'],
       data: [
         {
           time: 't1',

--- a/src/pages/admin-metrics.logic.ts
+++ b/src/pages/admin-metrics.logic.ts
@@ -140,6 +140,26 @@ export const buildDistributionPoints = (
   return points;
 };
 
+/**
+ * 图例 Top N 按窗口内真实请求数排序，而不是把每天的百分比等权相加。
+ * 后者会让低流量日的 100% 压过高流量日的大类，和“累计流量最高”文案不符。
+ */
+export const getDistributionCategoryOrder = (
+  points: readonly DistributionPoint[],
+): string[] => {
+  const totals = new Map<string, number>();
+  for (const point of points) {
+    totals.set(point.category, (totals.get(point.category) ?? 0) + point.count);
+  }
+  return Array.from(totals.entries())
+    .sort(([leftCategory, leftCount], [rightCategory, rightCount]) =>
+      rightCount === leftCount
+        ? leftCategory.localeCompare(rightCategory)
+        : rightCount - leftCount,
+    )
+    .map(([category]) => category);
+};
+
 export const formatDistributionTooltip = (point: DistributionPoint) =>
   `${point.value.toFixed(1)}% (${point.count.toLocaleString()})`;
 

--- a/src/pages/admin-metrics.tsx
+++ b/src/pages/admin-metrics.tsx
@@ -36,6 +36,7 @@ import {
   formatDistributionTooltip,
   formatTooltipItem,
   getCategoryPrefix,
+  getDistributionCategoryOrder,
   getMetricsTotal,
   getModeLabels,
   type MetricMode,
@@ -62,7 +63,10 @@ const DistributionPanel = ({
   const { isDark } = useThemeMode();
   const legendValuesRef = useRef<string[]>([]);
   const points = useMemo(() => buildDistributionPoints(rows), [rows]);
-  const { sortedCategories } = useMemo(() => aggregateSeries(points), [points]);
+  const sortedCategories = useMemo(
+    () => getDistributionCategoryOrder(points),
+    [points],
+  );
   const { defaultLegendValues, colorDomain } = useMemo(
     () => buildLegendDefaults(sortedCategories),
     [sortedCategories],
@@ -76,6 +80,7 @@ const DistributionPanel = ({
     xTitle: t('admin_metrics.time'),
     yTitle: t('admin_metrics.share_percent'),
     axisTimeFormat: 'MM/DD',
+    tooltipTimeFormat: 'MM/DD',
     formatTooltipValue: formatDistributionTooltip,
     colorDomain,
     legendValuesRef,

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -209,16 +209,16 @@ export const adminApi = {
       };
       quotaDetail: {
         limit: Quota;
-        todayRemaining: number;
-        todayUsed: number;
+        todayRemaining: number | null;
+        todayUsed: number | null;
         last7Days: {
           counts: number[];
           avg: number;
-        };
+        } | null;
       };
       apps: Array<
         AdminApp & {
-          checkCount: number;
+          checkCount: number | null;
           packagesCount: number;
         }
       >;

--- a/src/services/mutation-cache.test.ts
+++ b/src/services/mutation-cache.test.ts
@@ -14,8 +14,12 @@ const apps: App[] = [
 describe('app mutation cache updaters', () => {
   test('leave missing caches missing instead of synthesizing partial data', () => {
     expect(removeAppFromListCache(undefined, 1)).toBeUndefined();
-    expect(updateAppInListCache(undefined, 1, { name: 'renamed' })).toBeUndefined();
-    expect(updateAppDetailCache(undefined, { name: 'renamed' })).toBeUndefined();
+    expect(
+      updateAppInListCache(undefined, 1, { name: 'renamed' }),
+    ).toBeUndefined();
+    expect(
+      updateAppDetailCache(undefined, { name: 'renamed' }),
+    ).toBeUndefined();
   });
 
   test('remove only the requested app from an existing list', () => {

--- a/src/services/mutation-cache.test.ts
+++ b/src/services/mutation-cache.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import type { App } from '@/types';
+import {
+  removeAppFromListCache,
+  updateAppDetailCache,
+  updateAppInListCache,
+} from './mutation-cache';
+
+const apps: App[] = [
+  { id: 1, name: 'one', platform: 'android', appKey: 'key-1' },
+  { id: 2, name: 'two', platform: 'ios', appKey: 'key-2' },
+];
+
+describe('app mutation cache updaters', () => {
+  test('leave missing caches missing instead of synthesizing partial data', () => {
+    expect(removeAppFromListCache(undefined, 1)).toBeUndefined();
+    expect(updateAppInListCache(undefined, 1, { name: 'renamed' })).toBeUndefined();
+    expect(updateAppDetailCache(undefined, { name: 'renamed' })).toBeUndefined();
+  });
+
+  test('remove only the requested app from an existing list', () => {
+    expect(removeAppFromListCache({ data: apps }, 1)).toEqual({
+      data: [apps[1]],
+    });
+  });
+
+  test('update existing list and detail entries without mutating the source', () => {
+    const list = { data: apps };
+    const detail = apps[0];
+
+    expect(updateAppInListCache(list, 1, { name: 'renamed' })).toEqual({
+      data: [{ ...apps[0], name: 'renamed' }, apps[1]],
+    });
+    expect(updateAppDetailCache(detail, { name: 'renamed' })).toEqual({
+      ...detail,
+      name: 'renamed',
+    });
+    expect(list.data?.[0]?.name).toBe('one');
+    expect(detail?.name).toBe('one');
+  });
+});

--- a/src/services/mutation-cache.ts
+++ b/src/services/mutation-cache.ts
@@ -1,0 +1,36 @@
+import type { App } from '@/types';
+
+export type AppListCache = { data?: App[] };
+
+/** Do not create a synthetic empty list when the list query was never loaded. */
+export const removeAppFromListCache = (
+  old: AppListCache | undefined,
+  appId: number,
+): AppListCache | undefined =>
+  old
+    ? {
+        ...old,
+        data: (old.data ?? []).filter((app) => app.id !== appId),
+      }
+    : old;
+
+/** Apply an update only to an existing detail cache entry. */
+export const updateAppDetailCache = (
+  old: App | undefined,
+  params: Partial<App>,
+): App | undefined => (old ? { ...old, ...params } : old);
+
+/** Apply an update only to an existing list cache entry. */
+export const updateAppInListCache = (
+  old: AppListCache | undefined,
+  appId: number,
+  params: Partial<App>,
+): AppListCache | undefined =>
+  old
+    ? {
+        ...old,
+        data: (old.data ?? []).map((app) =>
+          app.id === appId ? { ...app, ...params } : app,
+        ),
+      }
+    : old;

--- a/src/services/mutations.ts
+++ b/src/services/mutations.ts
@@ -8,6 +8,11 @@ import {
 } from '@/utils/query-keys';
 import { queryClient } from '@/utils/queryClient';
 import { api } from './api';
+import {
+  removeAppFromListCache,
+  updateAppDetailCache,
+  updateAppInListCache,
+} from './mutation-cache';
 
 type UpdateAppParams = Omit<App, 'appKey' | 'checkCount' | 'id' | 'platform'>;
 
@@ -20,36 +25,23 @@ type UpdatePackageParams = {
 // --- cache updaters (single place that knows the cache shapes) ---
 
 const removeAppFromList = (appId: number) => {
-  queryClient.setQueryData(
-    appKeys.list(),
-    (old?: { data?: App[] } | undefined) => ({
-      data: old?.data?.filter((i) => i.id !== appId) ?? [],
-    }),
+  queryClient.setQueryData(appKeys.list(), (old?: { data?: App[] }) =>
+    removeAppFromListCache(old, appId),
   );
-};
-
-const addAppToList = (app: { id: number; name: string; platform: string }) => {
-  queryClient.setQueryData(
-    appKeys.list(),
-    (old?: { data?: App[] } | undefined) => ({
-      data: [...(old?.data || []), app],
-    }),
-  );
+  queryClient.removeQueries({ queryKey: appKeys.detail(appId), exact: true });
 };
 
 const applyAppUpdate = (appId: number, params: UpdateAppParams) => {
-  queryClient.setQueryData(appKeys.detail(appId), (old: App | undefined) => ({
-    ...old,
-    ...params,
-  }));
-  queryClient.setQueryData(
-    appKeys.list(),
-    (old?: { data?: App[] } | undefined) => ({
-      data:
-        old?.data?.map((i) => (i.id === appId ? { ...i, ...params } : i)) ?? [],
-    }),
+  queryClient.setQueryData(appKeys.detail(appId), (old: App | undefined) =>
+    updateAppDetailCache(old, params),
+  );
+  queryClient.setQueryData(appKeys.list(), (old?: { data?: App[] }) =>
+    updateAppInListCache(old, appId, params),
   );
 };
+
+const revalidateAppList = () =>
+  queryClient.invalidateQueries({ queryKey: appKeys.list() });
 
 const applyPackageUpdate = (
   appId: number,
@@ -147,7 +139,9 @@ const removeBindingFromList = (appId: number, bindingId: number) => {
 
 export const createApp = async (params: { name: string; platform: string }) => {
   const id = await api.createApp(params);
-  addAppToList({ ...params, id });
+  // The create endpoint returns only an id. Refetch the canonical entity list
+  // instead of inserting an object without appKey/status into a fresh cache.
+  await revalidateAppList();
   return id;
 };
 
@@ -156,7 +150,10 @@ export const createApp = async (params: { name: string; platform: string }) => {
 export const useDeleteApp = () =>
   useMutation({
     mutationFn: (appId: number) => api.deleteApp(appId),
-    onSuccess: (_data, appId) => removeAppFromList(appId),
+    onSuccess: async (_data, appId) => {
+      removeAppFromList(appId);
+      await revalidateAppList();
+    },
   });
 
 export const useUpdateApp = () =>
@@ -168,7 +165,13 @@ export const useUpdateApp = () =>
       appId: number;
       params: UpdateAppParams;
     }) => api.updateApp(appId, params),
-    onSuccess: (_data, { appId, params }) => applyAppUpdate(appId, params),
+    onSuccess: async (_data, { appId, params }) => {
+      applyAppUpdate(appId, params);
+      await Promise.all([
+        revalidateAppList(),
+        queryClient.invalidateQueries({ queryKey: appKeys.detail(appId) }),
+      ]);
+    },
   });
 
 export const useUpdatePackage = () =>

--- a/src/utils/charts.test.ts
+++ b/src/utils/charts.test.ts
@@ -37,7 +37,7 @@ describe('buildTimeSeriesLineConfig', () => {
     ).toBe('classicDark');
   });
 
-  test('formats the x axis with the requested time format', () => {
+  test('formats the x axis and tooltip with their requested time formats', () => {
     const local = dayjs(data[0]!.time);
     const config = buildTimeSeriesLineConfig({
       data,
@@ -52,6 +52,7 @@ describe('buildTimeSeriesLineConfig', () => {
       isDark: false,
       height: 1,
       axisTimeFormat: 'HH:mm',
+      tooltipTimeFormat: 'MM/DD',
     });
     expect(short.axis.x.labelFormatter(data[0]!.time)).toBe(
       local.format('HH:mm'),
@@ -59,6 +60,7 @@ describe('buildTimeSeriesLineConfig', () => {
     // 无法解析的刻度原样返回
     expect(config.axis.x.labelFormatter('not a date')).toBe('not a date');
     expect(config.tooltip.title(data[0]!)).toBe(local.format('MM/DD HH:mm'));
+    expect(short.tooltip.title(data[0]!)).toBe(local.format('MM/DD'));
   });
 
   test('wires titles, tooltip formatter and color domain', () => {

--- a/src/utils/charts.ts
+++ b/src/utils/charts.ts
@@ -24,6 +24,8 @@ export interface TimeSeriesLineOptions<P extends TimeSeriesPoint> {
   yTitle?: string;
   /** x 轴刻度的时间格式，默认 'MM/DD HH:mm'；节点面板只看当天用 'HH:mm'。 */
   axisTimeFormat?: string;
+  /** tooltip 标题的时间格式，默认 'MM/DD HH:mm'；日级图可只显示日期。 */
+  tooltipTimeFormat?: string;
   /** tooltip 单项的值文本；不传则交给 G2 默认渲染。 */
   formatTooltipValue?: (point: P) => string;
   /** 多条线同时命中时合并到一个 tooltip，默认开启。 */
@@ -38,7 +40,7 @@ export interface TimeSeriesLineOptions<P extends TimeSeriesPoint> {
 }
 
 const DEFAULT_AXIS_TIME_FORMAT = 'MM/DD HH:mm';
-const TOOLTIP_TIME_FORMAT = 'MM/DD HH:mm';
+const DEFAULT_TOOLTIP_TIME_FORMAT = 'MM/DD HH:mm';
 
 /**
  * 各指标页共用的时间序列折线图配置：主题跟随暗色模式、x 轴按时间格式化、
@@ -51,6 +53,7 @@ export function buildTimeSeriesLineConfig<P extends TimeSeriesPoint>({
   xTitle,
   yTitle,
   axisTimeFormat = DEFAULT_AXIS_TIME_FORMAT,
+  tooltipTimeFormat = DEFAULT_TOOLTIP_TIME_FORMAT,
   formatTooltipValue,
   sharedTooltip = true,
   colorDomain,
@@ -79,7 +82,7 @@ export function buildTimeSeriesLineConfig<P extends TimeSeriesPoint>({
       y: yTitle === undefined ? {} : { title: yTitle },
     },
     tooltip: {
-      title: (point: P) => dayjs(point.time).format(TOOLTIP_TIME_FORMAT),
+      title: (point: P) => dayjs(point.time).format(tooltipTimeFormat),
       ...(formatTooltipValue
         ? {
             items: [

--- a/src/utils/chunk-recovery.test.ts
+++ b/src/utils/chunk-recovery.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldReloadChunkError } from './chunk-recovery';
+
+describe('shouldReloadChunkError', () => {
+  test('allows one reload for each UI build', () => {
+    expect(shouldReloadChunkError(null, '2026.8.31-a')).toBe(true);
+    expect(shouldReloadChunkError('2026.8.31-a', '2026.8.31-a')).toBe(false);
+    expect(shouldReloadChunkError('2026.8.31-a', '2026.9.1-b')).toBe(true);
+  });
+});

--- a/src/utils/chunk-recovery.ts
+++ b/src/utils/chunk-recovery.ts
@@ -1,0 +1,11 @@
+export const CHUNK_ERROR_RELOAD_KEY = 'pushy_chunk_error_reload_attempted';
+
+/**
+ * Retry a stale chunk once per UI build. A later deployment has a different
+ * build id and therefore gets its own recovery attempt even if the previous
+ * marker is still present in the tab's session storage.
+ */
+export const shouldReloadChunkError = (
+  attemptedVersion: string | null,
+  currentVersion: string,
+) => attemptedVersion !== currentVersion;

--- a/src/utils/endpoint.test.ts
+++ b/src/utils/endpoint.test.ts
@@ -22,7 +22,9 @@ describe('normalizeEndpointUrl', () => {
   });
 
   test('rejects embedded credentials, query strings, fragments and non-http URLs', () => {
-    expect(normalizeEndpointUrl('https://user:pass@example.com/api')).toBeNull();
+    expect(
+      normalizeEndpointUrl('https://user:pass@example.com/api'),
+    ).toBeNull();
     expect(normalizeEndpointUrl('https://example.com/api?token=1')).toBeNull();
     expect(normalizeEndpointUrl('https://example.com/api#section')).toBeNull();
     expect(normalizeEndpointUrl('ftp://example.com/api')).toBeNull();

--- a/src/utils/endpoint.test.ts
+++ b/src/utils/endpoint.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeEndpointUrl } from './endpoint';
+
+describe('normalizeEndpointUrl', () => {
+  test('canonicalizes HTTPS endpoints and preserves an API path', () => {
+    expect(normalizeEndpointUrl(' https://example.com/api/ ')).toBe(
+      'https://example.com/api',
+    );
+    expect(normalizeEndpointUrl('https://example.com/')).toBe(
+      'https://example.com',
+    );
+  });
+
+  test('allows plain HTTP only for local development hosts', () => {
+    expect(normalizeEndpointUrl('http://localhost:9000/api')).toBe(
+      'http://localhost:9000/api',
+    );
+    expect(normalizeEndpointUrl('http://127.0.0.1:9000')).toBe(
+      'http://127.0.0.1:9000',
+    );
+    expect(normalizeEndpointUrl('http://example.com/api')).toBeNull();
+  });
+
+  test('rejects embedded credentials, query strings, fragments and non-http URLs', () => {
+    expect(normalizeEndpointUrl('https://user:pass@example.com/api')).toBeNull();
+    expect(normalizeEndpointUrl('https://example.com/api?token=1')).toBeNull();
+    expect(normalizeEndpointUrl('https://example.com/api#section')).toBeNull();
+    expect(normalizeEndpointUrl('ftp://example.com/api')).toBeNull();
+    expect(normalizeEndpointUrl('not a url')).toBeNull();
+  });
+});

--- a/src/utils/endpoint.ts
+++ b/src/utils/endpoint.ts
@@ -2,7 +2,42 @@ import { useEffect, useState } from 'react';
 import { safeStorage } from '@/utils/storage';
 
 const CUSTOM_BASE_URL_STORAGE_KEY = 'pushy_custom_base_url';
+const LOCAL_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '::1',
+  '[::1]',
+]);
 export const customBaseUrlChangeEvent = 'pushy-custom-base-url-change';
+
+/**
+ * Canonicalize a custom API base URL and reject values that would either be
+ * blocked as mixed content or conceal credentials/query data in the endpoint.
+ * Plain HTTP remains available for local development only.
+ */
+export function normalizeEndpointUrl(value: string): string | null {
+  try {
+    const url = new URL(value.trim());
+    const isLocal = LOCAL_HOSTNAMES.has(url.hostname);
+    const protocolAllowed =
+      url.protocol === 'https:' || (url.protocol === 'http:' && isLocal);
+    if (
+      !protocolAllowed ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+
+    const pathname = url.pathname.replace(/\/+$/, '');
+    return `${url.origin}${pathname}`;
+  } catch {
+    return null;
+  }
+}
 
 export function getCustomBaseUrl(): string | null {
   if (typeof window === 'undefined') {
@@ -62,18 +97,22 @@ export function useCustomBaseUrl(): string | null {
 }
 
 export async function testEndpointStatus(baseUrl: string): Promise<boolean> {
+  const normalizedUrl = normalizeEndpointUrl(baseUrl);
+  if (!normalizedUrl) {
+    return false;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
-    const cleanUrl = baseUrl.trim().replace(/\/$/, '');
-    const testUrl = `${cleanUrl}/status`;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
-    const response = await fetch(testUrl, {
+    const response = await fetch(`${normalizedUrl}/status`, {
       method: 'GET',
       signal: controller.signal,
     });
-    clearTimeout(timeoutId);
     return response.ok;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }


### PR DESCRIPTION
## What changed

- tolerate nullable Redis-backed quota and PV statistics in the admin user drawer
- show a retryable error state when the admin identity query fails instead of spinning forever
- stop create/update/delete mutations from synthesizing incomplete or empty app caches; refetch canonical data instead
- treat custom API endpoint changes as an authentication boundary by clearing the old session, workspace, and query cache before reload
- canonicalize endpoint URLs and allow plain HTTP only for local development
- bound the service-worker runtime cache and retry stale chunks once per UI build
- rank distribution-chart legends by cumulative request count rather than equal-weight daily percentages
- format daily distribution tooltips as dates without a meaningless `00:00`

## Tests added

- app mutation cache updater behavior
- custom endpoint URL normalization
- per-build chunk recovery guard
- distribution ranking under unequal daily traffic
- daily tooltip time formatting

## Deliberately not changed

The HttpOnly cookie login/logout rollout and credential transport are not modified in this PR.

## Validation

CI will run typecheck, Biome, Bun tests, production build, and bundle-size checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/pushy-admin/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790740944&installation_model_id=426977&pr_number=60&repository=reactnativecn%2Fpushy-admin&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Fpushy-admin%2Fpull%2F60&signature=b61cbcaa7293e2dca1f8ad6da9aec002238977bf2b970055f42a18a7b4a07ef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->